### PR TITLE
fix for webassembly link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-`wasm` is a library for reading and running [WebAssembly](webassembly.github.io) modules.
+`wasm` is a library for reading and running [WebAssembly](http://webassembly.github.io) modules.
 
 Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).


### PR DESCRIPTION
Cool project Josh! Was trying to click the link but it seems to have created a relative link instead of an absolute one!
